### PR TITLE
added force_rekey.py example

### DIFF
--- a/python/docs/force_rekey.md
+++ b/python/docs/force_rekey.md
@@ -1,0 +1,24 @@
+force_rekey.py
+===============================================
+### Description ###
+
+force_rekey.py script forces a VSD keyserver to reissue Seed, SEKs, and other primitives. The script triggers the particular Job "FORCE_KEYSERVER_UPDATE". A successful execution will emit a similar output in the stdout:
+```bash
+$ python force_rekey.py
+Starting FORCE_KEYSERVER_UPDATE job for the 521_CATS_FIXED Organization
+SUCCESS :: Re-keying Job succeeded!
+```
+
+The script could also be used as a primer on the VSPK's Job object handling.
+
+### Version history ###
+2018-04-26 - 1.0 - First version
+
+### Usage ###
+The example script has no cli parameters to handle, all the needed variables must be changed in the script body.
+```
+python force_rekey.py
+```
+
+### Author ###
+[Roman Dodin](dodin.roman@gmail.com)

--- a/python/force_rekey.py
+++ b/python/force_rekey.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+"""
+force_rekey.py forces a VSD keyserver to reissue Seed, SEKs, and other primitives.
+
+--- Author ---
+Roman Dodin <dodin.roman@gmail.com>
+
+--- Usage ---
+python force_rekey.py
+
+--- Documentation ---
+https://github.com/nuagenetworks/vspk-examples/blob/master/python/force_rekey.md
+"""
+
+import time
+
+from vspk import v5_0 as vspk
+
+
+def is_job_ready(job, timeout=600):
+    """
+    Waits for job to succeed and returns job.result
+    """
+
+    timeout_start = time.time()
+    while time.time() < timeout_start + timeout:
+        job.fetch()
+        if job.status == 'SUCCESS':
+            print('SUCCESS :: Re-keying Job succeeded!')
+            return True
+        if job.status == 'FAILED':
+            return False
+        time.sleep(1)
+    print('ERROR :: Job {} failed to return its status in {}sec interval'.format(
+        job.command, timeout))
+
+
+# Login variables
+n_username = 'csproot'
+n_password = 'csproot'
+n_org = 'csp'
+api_url = 'https://10.167.60.21:8443'
+
+# script variables
+org_name = '521_CATS_FIXED'
+job_timeout = 600  # in seconds
+
+nuage_session = vspk.NUVSDSession(
+    username=n_username,
+    password=n_password,
+    enterprise=n_org,
+    api_url=api_url)
+
+me = nuage_session.start().user
+
+# get parent for the re-key job object
+org = me.enterprises.get_first(filter='name == "{}"'.format(org_name))
+
+# create job object
+job = vspk.NUJob(command='FORCE_KEYSERVER_UPDATE')
+
+print('Starting {} job for the {} Organization'.format(
+    'FORCE_KEYSERVER_UPDATE',
+    org.name))
+
+# run job object under its parent
+org.create_child(job)
+
+# wait for object to finish
+is_job_ready(job, timeout=job_timeout)

--- a/python/force_rekey.py
+++ b/python/force_rekey.py
@@ -16,6 +16,15 @@ import time
 
 from vspk import v5_0 as vspk
 
+# Login variables
+n_username = 'csproot'
+n_password = 'csproot'
+n_org = 'csp'
+api_url = 'https://10.167.60.21:8443'
+
+# script variables
+org_name = '521_CATS_FIXED'
+job_timeout = 600  # in seconds
 
 def is_job_ready(job, timeout=600):
     """
@@ -33,17 +42,6 @@ def is_job_ready(job, timeout=600):
         time.sleep(1)
     print('ERROR :: Job {} failed to return its status in {}sec interval'.format(
         job.command, timeout))
-
-
-# Login variables
-n_username = 'csproot'
-n_password = 'csproot'
-n_org = 'csp'
-api_url = 'https://10.167.60.21:8443'
-
-# script variables
-org_name = '521_CATS_FIXED'
-job_timeout = 600  # in seconds
 
 nuage_session = vspk.NUVSDSession(
     username=n_username,


### PR DESCRIPTION
This is an addition to the python vspk examples that shows how to trigger embedded keyserver primitives upgrade 